### PR TITLE
Fix negative value to hex string bug 

### DIFF
--- a/iconsdk/utils/convert_type.py
+++ b/iconsdk/utils/convert_type.py
@@ -21,7 +21,7 @@ from iconsdk.exception import DataTypeException
 def convert_int_to_hex_str(value: int):
     """Converts an integer to hex string prefixed with '0x'."""
     if is_integer(value):
-        return add_0x_prefix(hex(value))
+        return hex(value)
     else:
         raise DataTypeException("Data type should be integer.")
 


### PR DESCRIPTION
## Problem

```
from iconsdk.builder.call_builder import CallBuilder
call = CallBuilder().from_(wallet.get_address())\
                    .to(SCORE_ADDR)\
                    .method("hello")\
                    .params({"value": -128})\
                    .build()

print(call.params)
```

This prints `{'value': '0x-0x80'}` that eventually cause JSONRPCException when send to rpc server.
