### PR TITLE
Add `set_channel` method on HTTPProvider

### DIFF
--- a/iconsdk/providers/config_api_path.py
+++ b/iconsdk/providers/config_api_path.py
@@ -1,3 +1,3 @@
 CONFIG_API_PATH = {
-    "debug_estimateStep": "/api/debug"
+    "debug_estimateStep": "api/debug"
 }

--- a/iconsdk/providers/http_provider.py
+++ b/iconsdk/providers/http_provider.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 import json
+import os
 from logging import getLogger
-from os.path import join
 from urllib.parse import urlparse
 from warnings import warn
 
@@ -73,7 +73,7 @@ class HTTPProvider(Provider):
     @dispatch(str, dict=None)
     def __init__(self, full_path_url: str, request_kwargs: dict = None):
         """
-        The previous initializer to be set with full path url which is only as like <scheme>://<host>/api/v3 without version.
+        The initializer to be set with full path url which is only as like <scheme>://<host>/api/v3 without version.
 
         :param full_path_url: full path URL as like <scheme>://<host>:<port>/api/v3
         :param request_kwargs: kwargs for setting to head of request
@@ -107,11 +107,11 @@ class HTTPProvider(Provider):
     def _get_full_path_url(self, method: str) -> str:
         url_components = urlparse(self._base_domain_url)
         if method in CONFIG_API_PATH:
-            path = join(CONFIG_API_PATH[method], 'v' + str(self._version))
+            path = os.path.join(CONFIG_API_PATH[method], 'v' + str(self._version))
         else:
-            path = join("api", "v" + str(self._version))
+            path = os.path.join("api", "v" + str(self._version))
         if self._channel is not None:
-            path = join(path, self._channel)
+            path = os.path.join(path, self._channel)
         url_components = url_components._replace(path=path)
         return url_components.geturl()
 

--- a/tests/providers/test_http_provider.py
+++ b/tests/providers/test_http_provider.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from os.path import join
 from unittest import TestCase, main
 
 from iconsdk.exception import URLException
@@ -37,10 +38,32 @@ class TestHTTPProvider(TestCase):
         invalid_url1 = "http://localhost:9000/api/v"
         invalid_url2 = "http://localhost:9000/api/"
         invalid_url3 = "http://localhost:9000"
+        invalid_url4 = "http://localhost:9000/api/debug/v3"
         self.assertRaises(URLException, HTTPProvider, invalid_url0)
         self.assertRaises(URLException, HTTPProvider, invalid_url1)
         self.assertRaises(URLException, HTTPProvider, invalid_url2)
         self.assertRaises(URLException, HTTPProvider, invalid_url3)
+        self.assertRaises(URLException, HTTPProvider, invalid_url4)
+
+    def test_set_http_provider_py_previous_initializer_with_valid_url(self):
+        valid_url1 = "http://localhost:9000/api/v3"
+
+        # When request kwargs is None
+        with self.assertWarns(Warning):
+            http_provider = HTTPProvider(valid_url1)
+        self.assertEqual({}, http_provider._request_kwargs)
+
+        # Checks full path url correctly
+        full_path_url_for_main_api = "http://localhost:9000/api/v3"
+        full_path_url_for_debug_api = "http://localhost:9000/api/debug/v3"
+        self.assertEqual(full_path_url_for_main_api, http_provider._get_full_path_url("icx_call"))
+        self.assertEqual(full_path_url_for_debug_api, http_provider._get_full_path_url("debug_estimateStep"))
+
+        # When request kwargs is
+        request_kwargs = {'timeout': 60, 'allow_redirects': False, 'verify': True}
+        with self.assertWarns(Warning):
+            http_provider = HTTPProvider(valid_url1, request_kwargs=request_kwargs)
+        self.assertEqual(request_kwargs, http_provider._request_kwargs)
 
     def test_set_http_provider_by_new_initializer_with_invalid_url(self):
         invalid_url0 = "localhost:9000"
@@ -63,6 +86,57 @@ class TestHTTPProvider(TestCase):
         self.assertTrue(http_provider.is_connected())
         icon_service = IconService(http_provider)
         self.assertEqual(type(icon_service.get_block("latest")), dict)
+
+    def test_set_http_provider_by_previous_initializer_with_channel(self):
+        full_path_url = "http://localhost:9000/api/v3/icon_dex"
+        self.assertRaises(URLException, HTTPProvider, full_path_url)
+
+        full_path_url_for_main_api = "http://localhost:9000/api/v3"
+        full_path_url_for_debug_api = "http://localhost:9000/api/debug/v3"
+        channel = "icon_dex"
+
+        http_provider = HTTPProvider(full_path_url_for_main_api)
+        self.assertTrue(http_provider.is_connected())
+
+        # set channel
+        http_provider.set_channel(channel)
+        self.assertEqual(join(full_path_url_for_main_api, channel), http_provider._get_full_path_url("icx_call"))
+        self.assertEqual(join(full_path_url_for_debug_api, channel),
+                         http_provider._get_full_path_url("debug_estimateStep"))
+
+        # set the other channel
+        channel = "icon_dex2"
+        http_provider.set_channel(channel)
+        self.assertEqual(join(full_path_url_for_main_api, channel), http_provider._get_full_path_url("icx_call"))
+        self.assertEqual(join(full_path_url_for_debug_api, channel),
+                         http_provider._get_full_path_url("debug_estimateStep"))
+
+    def test_set_http_provider_by_new_initializer_with_channel(self):
+        base_domain_url = "http://localhost:9000"
+        version = 3
+        channel = "icon_dex"
+        http_provider = HTTPProvider(base_domain_url, version)
+        self.assertTrue(http_provider.is_connected())
+
+        full_path_url_for_main_api = "http://localhost:9000/api/v3"
+        full_path_url_for_debug_api = "http://localhost:9000/api/debug/v3"
+
+        self.assertEqual(full_path_url_for_main_api, http_provider._get_full_path_url("icx_getTransactionByHash"))
+        self.assertEqual(full_path_url_for_main_api, http_provider._get_full_path_url("icx_call"))
+        self.assertEqual(full_path_url_for_debug_api, http_provider._get_full_path_url("debug_estimateStep"))
+
+        # set channel
+        http_provider.set_channel(channel)
+        self.assertEqual(join(full_path_url_for_main_api, channel), http_provider._get_full_path_url("icx_call"))
+        self.assertEqual(join(full_path_url_for_debug_api, channel),
+                         http_provider._get_full_path_url("debug_estimateStep"))
+
+        # set the other channel
+        channel = "icon_dex2"
+        http_provider.set_channel(channel)
+        self.assertEqual(join(full_path_url_for_main_api, channel), http_provider._get_full_path_url("icx_call"))
+        self.assertEqual(join(full_path_url_for_debug_api, channel),
+                         http_provider._get_full_path_url("debug_estimateStep"))
 
 
 if __name__ == "__main__":

--- a/tests/providers/test_http_provider.py
+++ b/tests/providers/test_http_provider.py
@@ -34,8 +34,13 @@ class TestHTTPProvider(TestCase):
         self.assertTrue(http_provider.is_connected())
 
     def test_set_http_provider_by_previous_initializer_with_invalid_url(self):
-        invalid_urls = ["http://localhost:9000/api/v2", "http://localhost:9000/api/v", "http://localhost:9000/api/",
-                        "http://localhost:9000", "http://localhost:9000/api/debug/v3"]
+        invalid_urls = [
+            "http://localhost:9000/api/v2",
+            "http://localhost:9000/api/v",
+            "http://localhost:9000/api/",
+            "http://localhost:9000",
+            "http://localhost:9000/api/debug/v3"
+        ]
         for invalid_url in invalid_urls:
             self.assertRaises(URLException, HTTPProvider, invalid_url)
 

--- a/tests/providers/test_http_provider.py
+++ b/tests/providers/test_http_provider.py
@@ -44,7 +44,7 @@ class TestHTTPProvider(TestCase):
         for invalid_url in invalid_urls:
             self.assertRaises(URLException, HTTPProvider, invalid_url)
 
-    def test_set_http_provider_py_previous_initializer_with_valid_url(self):
+    def test_set_http_provider_by_previous_initializer_with_valid_url(self):
         valid_url1 = "http://localhost:9000/api/v3"
 
         # When request kwargs is None

--- a/tests/providers/test_http_provider.py
+++ b/tests/providers/test_http_provider.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from os.path import join
+import os
 from unittest import TestCase, main
 
 from iconsdk.exception import URLException
@@ -34,16 +34,10 @@ class TestHTTPProvider(TestCase):
         self.assertTrue(http_provider.is_connected())
 
     def test_set_http_provider_by_previous_initializer_with_invalid_url(self):
-        invalid_url0 = "http://localhost:9000/api/v2"
-        invalid_url1 = "http://localhost:9000/api/v"
-        invalid_url2 = "http://localhost:9000/api/"
-        invalid_url3 = "http://localhost:9000"
-        invalid_url4 = "http://localhost:9000/api/debug/v3"
-        self.assertRaises(URLException, HTTPProvider, invalid_url0)
-        self.assertRaises(URLException, HTTPProvider, invalid_url1)
-        self.assertRaises(URLException, HTTPProvider, invalid_url2)
-        self.assertRaises(URLException, HTTPProvider, invalid_url3)
-        self.assertRaises(URLException, HTTPProvider, invalid_url4)
+        invalid_urls = ["http://localhost:9000/api/v2", "http://localhost:9000/api/v", "http://localhost:9000/api/",
+                        "http://localhost:9000", "http://localhost:9000/api/debug/v3"]
+        for invalid_url in invalid_urls:
+            self.assertRaises(URLException, HTTPProvider, invalid_url)
 
     def test_set_http_provider_py_previous_initializer_with_valid_url(self):
         valid_url1 = "http://localhost:9000/api/v3"
@@ -100,15 +94,17 @@ class TestHTTPProvider(TestCase):
 
         # set channel
         http_provider.set_channel(channel)
-        self.assertEqual(join(full_path_url_for_main_api, channel), http_provider._get_full_path_url("icx_call"))
-        self.assertEqual(join(full_path_url_for_debug_api, channel),
+        self.assertEqual(os.path.join(full_path_url_for_main_api, channel),
+                         http_provider._get_full_path_url("icx_call"))
+        self.assertEqual(os.path.join(full_path_url_for_debug_api, channel),
                          http_provider._get_full_path_url("debug_estimateStep"))
 
         # set the other channel
         channel = "icon_dex2"
         http_provider.set_channel(channel)
-        self.assertEqual(join(full_path_url_for_main_api, channel), http_provider._get_full_path_url("icx_call"))
-        self.assertEqual(join(full_path_url_for_debug_api, channel),
+        self.assertEqual(os.path.join(full_path_url_for_main_api, channel),
+                         http_provider._get_full_path_url("icx_call"))
+        self.assertEqual(os.path.join(full_path_url_for_debug_api, channel),
                          http_provider._get_full_path_url("debug_estimateStep"))
 
     def test_set_http_provider_by_new_initializer_with_channel(self):
@@ -127,15 +123,17 @@ class TestHTTPProvider(TestCase):
 
         # set channel
         http_provider.set_channel(channel)
-        self.assertEqual(join(full_path_url_for_main_api, channel), http_provider._get_full_path_url("icx_call"))
-        self.assertEqual(join(full_path_url_for_debug_api, channel),
+        self.assertEqual(os.path.join(full_path_url_for_main_api, channel),
+                         http_provider._get_full_path_url("icx_call"))
+        self.assertEqual(os.path.join(full_path_url_for_debug_api, channel),
                          http_provider._get_full_path_url("debug_estimateStep"))
 
         # set the other channel
         channel = "icon_dex2"
         http_provider.set_channel(channel)
-        self.assertEqual(join(full_path_url_for_main_api, channel), http_provider._get_full_path_url("icx_call"))
-        self.assertEqual(join(full_path_url_for_debug_api, channel),
+        self.assertEqual(os.path.join(full_path_url_for_main_api, channel),
+                         http_provider._get_full_path_url("icx_call"))
+        self.assertEqual(os.path.join(full_path_url_for_debug_api, channel),
                          http_provider._get_full_path_url("debug_estimateStep"))
 
 


### PR DESCRIPTION
- Refactors both the previous and the current version initializer on HTTPProvider
- Adds `set_channel` and `get_channel` on HTTPProvider
- Revises path on CONFIG_API_PATH
- Add unit tests for `set_channel` method
- Uses path module to parse path