### PR TITLE
IS-523: Support fee2.0 APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 install:
-- docker run -d -it --name tbears-container -p 9000:9000 iconloop/tbears:1.2.0-rc2
+- docker run -d -it --name tbears-container -p 9000:9000 iconloop/tbears:1.3.0-rc1
 
 script:
 - python setup.py test

--- a/README.md
+++ b/README.md
@@ -1050,7 +1050,7 @@ Builder for **DepositTransaction** object
 - to : SCORE address to receive a transaction
 - value : The amount of ICX to be deposited. It is used only for 'add' action. (Optional)
 - action : "add" or "withdraw".
-- Id : Transaction hash prefixed with '0x'. It is used only for 'withdraw' action. (Optional)
+- id : Transaction hash prefixed with '0x'. It is used only for 'withdraw' action. (Optional)
 - stepLimit : The maximum step value for processing a transaction.
 - nid : Network ID. Default nid is 1 if you didn't set the value. (1 for Main net, etc)
 - nonce :  An arbitrary number used to prevent transaction hash collision.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ ICON SDK for Python development and execution requires following environments.
 
 ### Version
 
-1.0.9 beta
+1.1.0 beta
 
 ### Installation
 
@@ -810,7 +810,8 @@ from iconsdk.builder.transaction_builder import (
     TransactionBuilder,
     DeployTransactionBuilder,
     CallTransactionBuilder,
-    MessageTransactionBuilder
+    MessageTransactionBuilder,
+    DepositTransactionBuilder
 )
 from iconsdk.signed_transaction import SignedTransaction
 
@@ -855,6 +856,29 @@ transaction = MessageTransactionBuilder()\
     .nid(3)\
     .nonce(100)\
     .data("0x74657374")\
+    .build()
+    
+# Generates an instance of transaction for adding or withdrawing a deposit.
+# Case0: Adding a deposit 
+transaction = DepositTransactionBuilder()\
+    .from_(wallet.get_address())\
+    .to("cx00...02")\
+    .value(5000*(10**18))\
+    .step_limit(1000000)\
+    .nid(3)\
+    .nonce(100)\
+    .action("add") \
+    .build()
+    
+# Case1: Withdrawing the deposit
+transaction = DepositTransactionBuilder()\
+    .from_(wallet.get_address())\
+    .to("cx00...02")\
+    .step_limit(1000000)\
+    .nid(3)\
+    .nonce(100)\
+    .action("withdraw") \
+    .id(tx_hash) \
     .build()
 
 # Returns the signed transaction object having a signature
@@ -1011,6 +1035,57 @@ transaction = MessageTransactionBuilder()\
     .nid(3)\
     .nonce(100)\
     .data("0x74657374")\
+    .build()
+```
+
+
+
+### DepositTransactionBuilder
+
+Builder for **DepositTransaction** object
+
+#### Methods
+
+- from_ : The wallet address making a transaction. The default address is your account address.
+- to : SCORE address to receive a transaction
+- value : The amount of ICX to be deposited. It is used only for 'add' action. (Optional)
+- action : "add" or "withdraw".
+- Id : Transaction hash prefixed with '0x'. It is used only for 'withdraw' action. (Optional)
+- stepLimit : The maximum step value for processing a transaction.
+- nid : Network ID. Default nid is 1 if you didn't set the value. (1 for Main net, etc)
+- nonce :  An arbitrary number used to prevent transaction hash collision.
+- version : Protocol version (3 for V3). The default version is 3 if you didn't set the value.
+- timestamp : Transaction creation time. Timestamp is in microseconds. Default timestamp is set, if you didn't set the value.
+- build : Returns a deposit transaction object.
+
+#### Returns
+
+A deposit transaction object  
+
+#### Example
+
+```python
+# Generates an instance of transaction for adding or withdrawing a deposit.
+# Case0: Adding a deposit 
+transaction = DepositTransactionBuilder()\
+    .from_(wallet.get_address())\
+    .to("cx00...02")\
+    .value(5000*(10**18))\
+    .step_limit(1000000)\
+    .nid(3)\
+    .nonce(100)\
+    .action("add") \
+    .build()
+    
+# Case1: Withdrawing the deposit
+transaction = DepositTransactionBuilder()\
+    .from_(wallet.get_address())\
+    .to("cx00...02")\
+    .step_limit(1000000)\
+    .nid(3)\
+    .nonce(100)\
+    .action("withdraw") \
+    .id(tx_hash) \
     .build()
 ```
 

--- a/iconsdk/builder/transaction_builder.py
+++ b/iconsdk/builder/transaction_builder.py
@@ -396,14 +396,14 @@ class DepositTransactionBuilder(TransactionBuilder):
 
     def build(self) -> DepositTransaction:
         if not self._action:
-            raise DataTypeException("'action' should be required. Available values for it are 'add' or 'withdraw'.")
+            raise DataTypeException("'action' should be provided. Available values are 'add' or 'withdraw'.")
         if self._action == "withdraw":
             if not self._id:
-                raise DataTypeException("When action is 'withdraw', 'id' should be required.")
+                raise DataTypeException("When action is 'withdraw', 'id' should be provided.")
             if self._value:
-                raise DataTypeException("When action is 'withdraw'. 'value' should not be required.")
+                raise DataTypeException("When action is 'withdraw'. 'value' should not be provided.")
         if self._action == "add" and not self._value:
-            raise DataTypeException("When action is 'add', 'value' should be required.")
+            raise DataTypeException("When action is 'add', 'value' should be provided.")
         return DepositTransaction(self._from_, self._to, self._value, self._step_limit, self._nid, self._nonce,
                                   self._version, self._timestamp, self._action, self._id)
 

--- a/iconsdk/builder/transaction_builder.py
+++ b/iconsdk/builder/transaction_builder.py
@@ -171,6 +171,33 @@ class MessageTransaction(Transaction):
         return transaction_as_dict
 
 
+class DepositTransaction(Transaction):
+    """Subclass `DepositTransaction`, making a transaction object for depositing  and withdrawing"""
+
+    def __init__(self, from_: str, to: str, value: int, step_limit: int, nid: int, nonce: int, version: int,
+                 timestamp: int, action: str, id: str):
+        Transaction.__init__(self, from_, to, value, step_limit, nid, nonce, version, timestamp)
+        self.__action = action
+        self.__id = id
+
+    @property
+    def data_type(self):
+        return "deposit"
+
+    @property
+    def action(self):
+        return self.__action
+
+    @property
+    def id(self):
+        return self.__id
+
+    def to_dict(self):
+        transaction_as_dict = super().to_dict()
+        transaction_as_dict.update({"data_type": self.data_type, "action": self.action, "id": self.id})
+        return transaction_as_dict
+
+
 class TransactionBuilder:
     """Builder for `Transaction` object"""
 
@@ -345,6 +372,48 @@ class MessageTransactionBuilder(TransactionBuilder):
         try:
             cls = super().from_dict(transaction_as_dict)
             cls.data(transaction_as_dict["data"])
+            return cls
+        except KeyError:
+            raise DataTypeException("The input data invalid. Mapping key not found.")
+
+
+class DepositTransactionBuilder(TransactionBuilder):
+    """Builder for `DepositTransaction` object"""
+
+    def __init__(self, from_: str = None, to: str = None, value: int = None, step_limit: int = None, nid: int = None,
+                 nonce: int = None, version: int = None, timestamp: int = None, action: str = None, id: str = None):
+        TransactionBuilder.__init__(self, from_, to, value, step_limit, nid, nonce, version, timestamp)
+        self._action = action
+        self._id = id
+
+    def action(self, action: str):
+        self._action = action
+        return self
+
+    def id(self, id: str):
+        self._id = id
+        return self
+
+    def build(self) -> DepositTransaction:
+        if not self._action:
+            raise DataTypeException("'action' should be required. Available values for it are 'add' or 'withdraw'.")
+        if self._action == "withdraw":
+            if not self._id:
+                raise DataTypeException("When action is 'withdraw', 'id' should be required.")
+            if self._value:
+                raise DataTypeException("When action is 'withdraw'. 'value' should not be required.")
+        if self._action == "add" and not self._value:
+            raise DataTypeException("When action is 'add', 'value' should be required.")
+        return DepositTransaction(self._from_, self._to, self._value, self._step_limit, self._nid, self._nonce,
+                                  self._version, self._timestamp, self._action, self._id)
+
+    @classmethod
+    def from_dict(cls, transaction_as_dict: dict) -> 'DepositTransactionBuilder':
+        """Returns a DepositTransactionBuilder made from dict"""
+        try:
+            cls = super().from_dict(transaction_as_dict)
+            cls.action(transaction_as_dict["action"])
+            cls.id(transaction_as_dict["id"] if "id" in transaction_as_dict else None)
             return cls
         except KeyError:
             raise DataTypeException("The input data invalid. Mapping key not found.")

--- a/iconsdk/signed_transaction.py
+++ b/iconsdk/signed_transaction.py
@@ -48,7 +48,7 @@ class SignedTransaction:
         return self.__signed_transaction_dict
 
     @staticmethod
-    def convert_tx_to_jsonrpc_request(transaction, wallet: Wallet = None) -> dict:
+    def convert_tx_to_jsonrpc_request(transaction: Transaction, wallet: Wallet = None) -> dict:
         """Converts an instance of the transaction into JSON RPC request in dict"""
         dict_tx = {
             "version": convert_int_to_hex_str(transaction.version) if transaction.version else "0x3",
@@ -72,5 +72,9 @@ class SignedTransaction:
             dict_tx["data"] = generate_data_value(transaction)
         elif transaction.data_type == 'message':
             dict_tx["data"] = transaction.data
+        elif transaction.data_type == "deposit":
+            dict_tx["data"] = {"action": transaction.action}
+            if transaction.action == "withdraw" and transaction.id:
+                dict_tx["data"]["id"] = transaction.id
 
         return dict_tx

--- a/iconsdk/utils/validation.py
+++ b/iconsdk/utils/validation.py
@@ -244,3 +244,24 @@ def is_message_transaction(params: dict) -> bool:
            and has_keys(params, inner_key_of_params) \
            and is_0x_prefixed(params["data"]) \
            and params["dataType"] == "message"
+
+
+def is_deposit_transaction(params: dict, deposit_type: str) -> bool:
+    """Checks an instance of `DepositTransaction` has right format.
+
+    :param params:
+    :param deposit_type: add or withdraw
+    :return: bool
+    """
+    inner_key_of_params = ['dataType', 'data']
+    inner_key_of_data_for_add_action = ["action"]
+    inner_key_of_data_for_withdraw_action = ["action", "id"]
+
+    checked: bool = has_keys(params, inner_key_of_params) and params["dataType"] == "deposit"
+
+    if deposit_type == "withdraw":
+        return has_keys(params["data"], inner_key_of_data_for_withdraw_action) \
+               and is_0x_prefixed(params["data"]["id"]) and params["data"]["action"] == "withdraw" and checked
+    else:
+        return has_keys(params["data"], inner_key_of_data_for_add_action) \
+               and params["data"]["action"] == "add" and checked

--- a/tests/api_send/test_send_deposit.py
+++ b/tests/api_send/test_send_deposit.py
@@ -1,0 +1,41 @@
+from iconsdk.builder.transaction_builder import DepositTransactionBuilder, DepositTransaction
+from iconsdk.signed_transaction import SignedTransaction
+from iconsdk.utils.validation import is_T_HASH
+from tests.api_send.test_send_super import TestSendSuper
+
+
+class TestSendDeposit(TestSendSuper):
+
+    def test_add_deposit(self):
+        # transaction instance for add action
+        deposit_transaction_of_add_0: DepositTransaction = DepositTransactionBuilder() \
+            .from_(self.setting["from"]) \
+            .to(self.setting["to"]) \
+            .value(self.setting["value"]) \
+            .step_limit(self.setting["step_limit"]) \
+            .nid(self.setting["nid"]) \
+            .nonce(self.setting["nonce"]) \
+            .action("add") \
+            .build()
+
+        # Checks if sending transaction correctly
+        signed_transaction_dict = SignedTransaction(deposit_transaction_of_add_0, self.wallet)
+        result = self.icon_service.send_transaction(signed_transaction_dict)
+        self.assertTrue(is_T_HASH(result))
+
+    def test_withdraw_deposit(self):
+        # transaction instance for withdraw action
+        deposit_transaction_of_withdraw_0: DepositTransaction = DepositTransactionBuilder() \
+            .from_(self.setting["from"]) \
+            .to(self.setting["to"]) \
+            .step_limit(self.setting["step_limit"]) \
+            .nid(self.setting["nid"]) \
+            .nonce(self.setting["nonce"]) \
+            .id(self.setting["id"]) \
+            .action("withdraw") \
+            .build()
+
+        # Checks if sending transaction correctly
+        signed_transaction_dict = SignedTransaction(deposit_transaction_of_withdraw_0, self.wallet)
+        result = self.icon_service.send_transaction(signed_transaction_dict)
+        self.assertTrue(is_T_HASH(result))

--- a/tests/api_send/test_send_super.py
+++ b/tests/api_send/test_send_super.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from unittest import TestCase, main
 
 from iconsdk.icon_service import IconService
@@ -26,6 +27,7 @@ class TestSendSuper(TestCase):
     A super class of other send test class, it is for unit tests of sending transaction.
     All of sup classes for testing sending transaction extends this super class.
     """
+
     @classmethod
     def setUpClass(cls):
         """
@@ -74,7 +76,8 @@ class TestSendSuper(TestCase):
                 "init_supply": 10000
             },
             # It is used to send message only.
-            "data": "0x" + "test".encode().hex()
+            "data": "0x" + "test".encode().hex(),
+            "id": "0x" + os.urandom(32).hex()
         }
 
 

--- a/tests/api_send/test_signed_transaction.py
+++ b/tests/api_send/test_signed_transaction.py
@@ -16,17 +16,17 @@
 from unittest import main
 
 from iconsdk.builder.transaction_builder import TransactionBuilder, MessageTransactionBuilder, \
-    CallTransactionBuilder, DeployTransactionBuilder
+    CallTransactionBuilder, DeployTransactionBuilder, DepositTransactionBuilder, DepositTransaction
 from iconsdk.exception import DataTypeException
 from iconsdk.signed_transaction import SignedTransaction
 from iconsdk.utils.validation import is_icx_transaction, is_call_transaction, is_message_transaction, \
-    is_deploy_transaction, is_T_HASH
+    is_deploy_transaction, is_T_HASH, is_deposit_transaction
 from tests.api_send.test_send_super import TestSendSuper
 
 
 class TestSignedTransaction(TestSendSuper):
 
-    def test_to_dict(self):
+    def test_convert_tx_to_jsonrpc_request_for_icx_transaction(self):
         # Transfer
         # When having an optional property, nonce
         icx_transaction = TransactionBuilder().from_(self.setting["from"]).to(self.setting["to"]) \
@@ -45,6 +45,7 @@ class TestSignedTransaction(TestSendSuper):
         tx_dict = SignedTransaction.convert_tx_to_jsonrpc_request(icx_transaction)
         self.assertFalse(is_icx_transaction(tx_dict))
 
+    def test_convert_tx_to_jsonrpc_request_for_deploy_transaction(self):
         # Update SCORE
         deploy_transaction = DeployTransactionBuilder().from_(self.setting["from"]).to(self.setting["to"]) \
             .step_limit(self.setting["step_limit"]).nid(self.setting["nid"]).content_type(self.setting["content_type"]) \
@@ -60,6 +61,7 @@ class TestSignedTransaction(TestSendSuper):
         tx_dict = SignedTransaction.convert_tx_to_jsonrpc_request(deploy_transaction)
         self.assertTrue(is_deploy_transaction(tx_dict))
 
+    def test_convert_tx_to_jsonrpc_request_for_call_transaction(self):
         # SCORE method call
         call_transaction = CallTransactionBuilder().from_(self.setting["from"]).to(self.setting["to"]) \
             .step_limit(self.setting["step_limit"]).nid(self.setting["nid"]).nonce(self.setting["nonce"]) \
@@ -67,11 +69,40 @@ class TestSignedTransaction(TestSendSuper):
         tx_dict = SignedTransaction.convert_tx_to_jsonrpc_request(call_transaction)
         self.assertTrue(is_call_transaction(tx_dict))
 
+    def test_convert_tx_to_jsonrpc_request_for_message_transaction(self):
         # Message send
         msg_transaction = MessageTransactionBuilder().from_(self.setting["from"]).to(self.setting["to"]) \
             .step_limit(self.setting["step_limit"]).nid(self.setting["nid"]).data(self.setting["data"]).build()
         tx_dict = SignedTransaction.convert_tx_to_jsonrpc_request(msg_transaction)
         self.assertTrue(is_message_transaction(tx_dict))
+
+    def test_convert_tx_to_jsonrpc_request_for_add_deposit_transaction(self):
+        # Add deposit
+        add_deposit_transaction: DepositTransaction = DepositTransactionBuilder() \
+            .from_(self.setting["from"]) \
+            .to(self.setting["to"]) \
+            .value(self.setting["value"]) \
+            .step_limit(self.setting["step_limit"]) \
+            .nid(self.setting["nid"]) \
+            .nonce(self.setting["nonce"]) \
+            .action("add") \
+            .build()
+        tx_dict = SignedTransaction.convert_tx_to_jsonrpc_request(add_deposit_transaction)
+        self.assertTrue(is_deposit_transaction(tx_dict, "add"))
+
+    def test_convert_tx_to_jsonrpc_request_for_withdraw_deposit_transaction(self):
+        # Withdraw deposit
+        withdraw_deposit_transaction: DepositTransaction = DepositTransactionBuilder() \
+            .from_(self.setting["from"]) \
+            .to(self.setting["to"]) \
+            .step_limit(self.setting["step_limit"]) \
+            .nid(self.setting["nid"]) \
+            .nonce(self.setting["nonce"]) \
+            .id(self.setting["id"]) \
+            .action("withdraw") \
+            .build()
+        tx_dict = SignedTransaction.convert_tx_to_jsonrpc_request(withdraw_deposit_transaction)
+        self.assertTrue(is_deposit_transaction(tx_dict, "withdraw"))
 
     def test_signed_transaction_transfer(self):
         icx_transaction = TransactionBuilder().from_(self.wallet.get_address()).to(self.setting["to"]) \
@@ -137,6 +168,44 @@ class TestSignedTransaction(TestSendSuper):
 
         # success with param of step limit
         signed_transaction_dict = SignedTransaction(msg_transaction_without_step_limit, self.wallet,
+                                                    self.setting["step_limit"])
+        result = self.icon_service.send_transaction(signed_transaction_dict)
+        self.assertTrue(is_T_HASH(result))
+
+    def test_signed_transaction_with_deposit_transaction_of_add_action_without_step_limit(self):
+        deposit_transaction_without_step_limit: DepositTransaction = DepositTransactionBuilder() \
+            .from_(self.setting["from"]) \
+            .to(self.setting["to"]) \
+            .value(self.setting["value"]) \
+            .nid(self.setting["nid"]) \
+            .nonce(self.setting["nonce"]) \
+            .action("add") \
+            .build()
+
+        # fail without step limit
+        self.assertRaises(DataTypeException, SignedTransaction, deposit_transaction_without_step_limit, self.wallet)
+
+        # success with param of step limit
+        signed_transaction_dict = SignedTransaction(deposit_transaction_without_step_limit, self.wallet,
+                                                    self.setting["step_limit"])
+        result = self.icon_service.send_transaction(signed_transaction_dict)
+        self.assertTrue(is_T_HASH(result))
+
+    def test_signed_transaction_with_deposit_transaction_of_deposit_action_without_step_limit(self):
+        deposit_transaction_without_step_limit: DepositTransaction = DepositTransactionBuilder() \
+            .from_(self.setting["from"]) \
+            .to(self.setting["to"]) \
+            .nid(self.setting["nid"]) \
+            .nonce(self.setting["nonce"]) \
+            .action("withdraw") \
+            .id(self.setting["id"]) \
+            .build()
+
+        # fail without step limit
+        self.assertRaises(DataTypeException, SignedTransaction, deposit_transaction_without_step_limit, self.wallet)
+
+        # success with param of step limit
+        signed_transaction_dict = SignedTransaction(deposit_transaction_without_step_limit, self.wallet,
                                                     self.setting["step_limit"])
         result = self.icon_service.send_transaction(signed_transaction_dict)
         self.assertTrue(is_T_HASH(result))


### PR DESCRIPTION
- Add DepositTransaction and DepositTransactionBuilder
  - Applied to sign
  - Adds validation of deposit transaction
- Add test cases to validate deploy transaction
 
  - test cases for deposit in detail
    -  getting transaction result correctly
    - unit and integration tests for adding and withdrawing a deposit
    - revising setting data by adding id value for withdrawing
    - signing with a deposit transaction
    - generating deposit transaction by its builder