### PR TITLE
Compress the zipfile as much as possible

### DIFF
--- a/iconsdk/libs/in_memory_zip.py
+++ b/iconsdk/libs/in_memory_zip.py
@@ -59,7 +59,7 @@ class InMemoryZip:
         try:
             # when it is a zip file
             if path.isfile(_path):
-                zf = ZipFile(_path, 'r', ZIP_DEFLATED, False)
+                zf = ZipFile(_path, 'r', ZIP_DEFLATED, False, compresslevel=9)
                 zf.testzip()
                 with open(_path, mode='rb') as fp:
                     fp.seek(0)
@@ -68,7 +68,7 @@ class InMemoryZip:
             else:
                 # root path for figuring out directory of tests
                 tmp_root = None
-                with ZipFile(self._in_memory, 'a', ZIP_DEFLATED, False) as zf:
+                with ZipFile(self._in_memory, 'a', ZIP_DEFLATED, False, compresslevel=9) as zf:
                     for root, folders, files in walk(_path):
                         if 'package.json' in files:
                             tmp_root = root

--- a/iconsdk/libs/in_memory_zip.py
+++ b/iconsdk/libs/in_memory_zip.py
@@ -59,7 +59,7 @@ class InMemoryZip:
         try:
             # when it is a zip file
             if path.isfile(_path):
-                zf = ZipFile(_path, 'r', ZIP_DEFLATED, False, compresslevel=9)
+                zf = ZipFile(_path, 'r', ZIP_DEFLATED, False)
                 zf.testzip()
                 with open(_path, mode='rb') as fp:
                     fp.seek(0)


### PR DESCRIPTION
For big contracts, the 2,500,000,000 step limit may be reached because the zipfile isn't compressed well enough

`compresslevel` parameter has been added since python 3.7

https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile