### PR TITLE
fix generate url map to add channel path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,13 @@ dist: bionic
 python:
   - "3.7"
 
+install:
+  - virtualenv venv
+  - source venv/bin/activate
+  - pip install -e .[tests]
+
 script:
-  - python setup.py test
+  - python -m pytest -ra
 
 deploy:
   provider: pypi

--- a/iconsdk/providers/http_provider.py
+++ b/iconsdk/providers/http_provider.py
@@ -69,9 +69,14 @@ class HTTPProvider(Provider):
         self._generate_url_map()
 
     def _generate_url_map(self):
+        def _add_channel_path(url: str):
+            if self._channel:
+                return f"{url}/{self._channel}"
+            return url
+
         self._URL_MAP = {
-            'icx': "{0}/api/v{1}/{2}".format(self._serverUri, self._version, self._channel),
-            'debug': "{0}/api/debug/v{1}/{2}".format(self._serverUri, self._version, self._channel)
+            'icx': _add_channel_path(f"{self._serverUri}/api/v{self._version}"),
+            'debug': _add_channel_path(f"{self._serverUri}/api/debug/v{self._version}")
         }
 
     @staticmethod

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,10 @@ with open("README.md", 'r') as f:
 with open("requirements.txt") as requirements:
     requires = list(requirements)
 
+extras_requires = {
+    'tests': ['pytest~=6.2.5']
+}
+
 setup(
     name='iconsdk',
     version=version,
@@ -22,6 +26,7 @@ setup(
     url='https://github.com/icon-project/icon-sdk-python',
     packages=find_packages(exclude=['tests*']),
     install_requires=requires,
+    extras_require=extras_requires,
     python_requires='~=3.7',
     license='Apache License 2.0',
     classifiers=[

--- a/tests/api_call/test_call.py
+++ b/tests/api_call/test_call.py
@@ -12,20 +12,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import requests_mock
 import json
-
 from unittest import main
 from unittest.mock import patch
+
+import requests_mock
+
 from iconsdk.builder.call_builder import CallBuilder
 from tests.api_send.test_send_super import TestSendSuper
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
 class TestCall(TestSendSuper):
 
     def test_call(self, _make_id):
+
         # with from
         test_call = CallBuilder() \
             .from_(self.setting["from"]) \
@@ -49,7 +50,7 @@ class TestCall(TestSendSuper):
                 }
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result = self.icon_service.call(test_call)
             actual_request = json.loads(m._adapter.last_request.text)
             self.assertEqual(expected_request, actual_request)
@@ -76,7 +77,7 @@ class TestCall(TestSendSuper):
                     "from": self.setting["from"]
                 }
             }
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result = self.icon_service.call(test_call)
             actual_request = json.loads(m._adapter.last_request.text)
             self.assertEqual(expected_request, actual_request)
@@ -101,7 +102,7 @@ class TestCall(TestSendSuper):
                     },
                 }
             }
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result = self.icon_service.call(test_call)
             actual_request = json.loads(m._adapter.last_request.text)
             self.assertEqual(expected_request, actual_request)

--- a/tests/api_debug/test_estimate_step.py
+++ b/tests/api_debug/test_estimate_step.py
@@ -1,15 +1,18 @@
 import json
+import re
+from unittest.mock import patch
+
 import requests_mock
 
-from unittest.mock import patch
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 from iconsdk.builder.transaction_builder import DeployTransactionBuilder, CallTransactionBuilder
 from iconsdk.builder.transaction_builder import TransactionBuilder, MessageTransactionBuilder
 from tests.api_send.test_send_super import TestSendSuper
+from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
 class TestEstimateStep(TestSendSuper):
+    matcher = re.compile(re.escape(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/debug/v3/") + "?")
 
     def test_estimate_step_with_send_icx_transaction(self, _make_id):
         icx_transaction = TransactionBuilder() \
@@ -46,7 +49,7 @@ class TestEstimateStep(TestSendSuper):
                 'id': 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/debug/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result = self.icon_service.estimate_step(icx_transaction)
             actual_request = json.loads(m._adapter.last_request.text)
 
@@ -88,7 +91,7 @@ class TestEstimateStep(TestSendSuper):
                 'id': 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/debug/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result = self.icon_service.estimate_step(message_transaction)
             actual_request = json.loads(m._adapter.last_request.text)
 
@@ -138,7 +141,7 @@ class TestEstimateStep(TestSendSuper):
                 'id': 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/debug/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result = self.icon_service.estimate_step(deploy_transaction)
             actual_request = json.loads(m._adapter.last_request.text)
 
@@ -186,7 +189,7 @@ class TestEstimateStep(TestSendSuper):
                 'result': hex(expected_step),
                 'id': 1234
             }
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/debug/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result = self.icon_service.estimate_step(call_transaction)
             actual_request = json.loads(m._adapter.last_request.text)
 

--- a/tests/api_full_response/test_full_response_base.py
+++ b/tests/api_full_response/test_full_response_base.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from tests.api_send.test_send_super import TestSendSuper
 
 

--- a/tests/api_full_response/test_get_balance.py
+++ b/tests/api_full_response/test_get_balance.py
@@ -12,15 +12,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import requests_mock
-import json
 
+import json
 from unittest import main
 from unittest.mock import patch
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
-from tests.api_full_response.test_full_response_base import TestFullResponseBase
-from tests.api_full_response.example_response import result_success_v3
+
+import requests_mock
+
 from iconsdk.exception import AddressException
+from tests.api_full_response.example_response import result_success_v3
+from tests.api_full_response.test_full_response_base import TestFullResponseBase
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
@@ -44,7 +45,7 @@ class TestFullResponseGetBalance(TestFullResponseBase):
                 'id': 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result_dict = self.icon_service.get_balance(self.setting['from'], full_response=True)
             actual_request = json.loads(m._adapter.last_request.text)
             result_keys = result_dict.keys()

--- a/tests/api_full_response/test_get_block_by_hash.py
+++ b/tests/api_full_response/test_get_block_by_hash.py
@@ -14,11 +14,10 @@
 # limitations under the License.
 
 import json
-import requests_mock
-
-from unittest.mock import patch
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 from unittest import main
+from unittest.mock import patch
+
+import requests_mock
 
 from iconsdk.utils.validation import is_block
 from tests.api_full_response.example_response import result_error_v3, result_success_v3
@@ -46,7 +45,7 @@ class TestFullResponseGetBlockByHash(TestFullResponseBase):
                 'id': 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result_dict = self.icon_service.get_block(self.block_hash, full_response=True)
             actual_request = json.loads(m._adapter.last_request.text)
             result_keys = result_dict.keys()
@@ -70,7 +69,7 @@ class TestFullResponseGetBlockByHash(TestFullResponseBase):
                 'id': 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json, status_code=400)
+            m.post(self.matcher, json=response_json, status_code=400)
             result_dict = self.icon_service.get_block(invalid_block_hash, full_response=True)
             self.assertEqual(result_dict.keys(), result_error_v3.keys())
 

--- a/tests/api_full_response/test_get_block_by_height.py
+++ b/tests/api_full_response/test_get_block_by_height.py
@@ -14,11 +14,10 @@
 # limitations under the License.
 
 import json
-import requests_mock
-
-from unittest.mock import patch
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 from unittest import main
+from unittest.mock import patch
+
+import requests_mock
 
 from iconsdk.utils.validation import is_block
 from tests.api_full_response.example_response import result_error_v3, result_success_v3
@@ -46,7 +45,7 @@ class TestFullResponseGetBlockByHeight(TestFullResponseBase):
                 'id': 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result_dict = self.icon_service.get_block(self.block_height, full_response=True)
             actual_request = json.loads(m._adapter.last_request.text)
             result_keys = result_dict.keys()
@@ -70,7 +69,7 @@ class TestFullResponseGetBlockByHeight(TestFullResponseBase):
                 "id": 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json, status_code=400)
+            m.post(self.matcher, json=response_json, status_code=400)
             result_dict = self.icon_service.get_block(invalid_block_height, full_response=True)
             self.assertEqual(result_dict.keys(), result_error_v3.keys())
 

--- a/tests/api_full_response/test_get_last_block.py
+++ b/tests/api_full_response/test_get_last_block.py
@@ -14,11 +14,10 @@
 # limitations under the License.
 
 import json
-import requests_mock
-
-from unittest.mock import patch
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 from unittest import main
+from unittest.mock import patch
+
+import requests_mock
 
 from iconsdk.utils.validation import is_block
 from tests.api_full_response.example_response import result_success_v3
@@ -43,7 +42,7 @@ class TestFullResponseGetBlockByHeight(TestFullResponseBase):
                 'id': 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result_dict = self.icon_service.get_block("latest", full_response=True)
             actual_request = json.loads(m._adapter.last_request.text)
             result_keys = result_dict.keys()

--- a/tests/api_full_response/test_get_score_api.py
+++ b/tests/api_full_response/test_get_score_api.py
@@ -13,14 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import requests_mock
 import json
-
-from unittest.mock import patch
 from unittest import main
+from unittest.mock import patch
+
+import requests_mock
 
 from iconsdk.utils.validation import is_score_apis
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 from tests.api_full_response.example_response import result_success_v3, result_error_v3
 from tests.api_full_response.test_full_response_base import TestFullResponseBase
 
@@ -40,7 +39,7 @@ class TestFullResponseGetScoreAPI(TestFullResponseBase):
                 }
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_governance_json)
+            m.post(self.matcher, json=response_governance_json)
             result_dict = self.icon_service.get_score_api(governance_address, full_response=True)
             actual_request = json.loads(m._adapter.last_request.text)
             result_content = result_dict['result']
@@ -61,7 +60,7 @@ class TestFullResponseGetScoreAPI(TestFullResponseBase):
                 },
                 "id": 1234
             }
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json, status_code=400)
+            m.post(self.matcher, json=response_json, status_code=400)
             result_dict = self.icon_service.get_score_api(wrong_address, full_response=True)
             self.assertEqual(result_dict.keys(), result_error_v3.keys())
 

--- a/tests/api_full_response/test_get_total_supply.py
+++ b/tests/api_full_response/test_get_total_supply.py
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import requests_mock
 import json
-
 from unittest import main
 from unittest.mock import patch
+
+import requests_mock
+
 from tests.api_full_response.example_response import result_success_v3
 from tests.api_full_response.test_full_response_base import TestFullResponseBase
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
@@ -40,7 +40,7 @@ class TesFullResponseGetTotalSupply(TestFullResponseBase):
                 'result': hex(supply),
                 'id': 1234
             }
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result_dict = self.icon_service.get_total_supply(full_response=True)
             actual_request = json.loads(m._adapter.last_request.text)
             result_content = result_dict['result']

--- a/tests/api_full_response/test_get_transaction_by_hash.py
+++ b/tests/api_full_response/test_get_transaction_by_hash.py
@@ -12,16 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import requests_mock
 import json
-
 from unittest import main
 from unittest.mock import patch
+
+import requests_mock
 
 from iconsdk.utils.validation import is_transaction
 from tests.api_full_response.example_response import result_success_v3, result_error_v3
 from tests.api_full_response.test_full_response_base import TestFullResponseBase
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
@@ -43,7 +42,7 @@ class TestFullResponseGetTransactionByHash(TestFullResponseBase):
                 "id": 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result_dict = self.icon_service.get_transaction(self.transaction_hash, full_response=True)
             actual_request = json.loads(m._adapter.last_request.text)
             result_content = result_dict['result']
@@ -64,7 +63,7 @@ class TestFullResponseGetTransactionByHash(TestFullResponseBase):
                 "id": 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json, status_code=400)
+            m.post(self.matcher, json=response_json, status_code=400)
             result_dict = self.icon_service.get_block(wrong_tx_hash, full_response=True)
             self.assertEqual(result_dict.keys(), result_error_v3.keys())
 

--- a/tests/api_full_response/test_get_transaction_result.py
+++ b/tests/api_full_response/test_get_transaction_result.py
@@ -13,16 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import requests_mock
 import json
-
 from unittest import main
 from unittest.mock import patch
 
-from tests.api_full_response.example_response import result_success_v3, result_error_v3
+import requests_mock
+
 from iconsdk.utils.validation import is_transaction_result
+from tests.api_full_response.example_response import result_success_v3, result_error_v3
 from tests.api_full_response.test_full_response_base import TestFullResponseBase
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
@@ -43,7 +42,7 @@ class TestGetTransactionResult(TestFullResponseBase):
                 "result": self.receipt,
                 "id": 1234
             }
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result_dict = self.icon_service.get_transaction_result(self.transaction_hash, full_response=True)
             actual_request = json.loads(m._adapter.last_request.text)
             result_content = result_dict['result']
@@ -64,7 +63,7 @@ class TestGetTransactionResult(TestFullResponseBase):
                 "id": 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json, status_code=400)
+            m.post(self.matcher, json=response_json, status_code=400)
             result_dict = self.icon_service.get_block(wrong_tx_hash, full_response=True)
             self.assertEqual(result_dict.keys(), result_error_v3.keys())
 

--- a/tests/api_full_response/test_send_call.py
+++ b/tests/api_full_response/test_send_call.py
@@ -13,17 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import requests_mock
 import json
-
-from unittest import main
 from unittest.mock import patch
+
+import requests_mock
+
 from iconsdk.builder.transaction_builder import CallTransactionBuilder
 from iconsdk.signed_transaction import SignedTransaction
 from iconsdk.utils.validation import is_T_HASH
 from tests.api_full_response.example_response import result_success_v3, result_error_v3
 from tests.api_full_response.test_full_response_base import TestFullResponseBase
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
@@ -47,7 +46,7 @@ class TesFullResponseSendDeploy(TestFullResponseBase):
                 'result': '0x4bf74e6aeeb43bde5dc8d5b62537a33ac8eb7605ebbdb51b015c1881b45b3aed'
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result_dict = self.icon_service.send_transaction(signed_transaction, full_response=True)
             actual_request = json.loads(m._adapter.last_request.text)
             result_content = result_dict['result']
@@ -78,6 +77,6 @@ class TesFullResponseSendDeploy(TestFullResponseBase):
                 }
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result_dict = self.icon_service.send_transaction(signed_transaction, full_response=True)
             self.assertEqual(result_error_v3.keys(), result_dict.keys())

--- a/tests/api_full_response/test_send_deploy.py
+++ b/tests/api_full_response/test_send_deploy.py
@@ -13,17 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import requests_mock
 import json
-
 from unittest import main
 from unittest.mock import patch
+
+import requests_mock
+
 from iconsdk.builder.transaction_builder import DeployTransactionBuilder
 from iconsdk.signed_transaction import SignedTransaction
 from iconsdk.utils.validation import is_T_HASH
 from tests.api_full_response.example_response import result_success_v3, result_error_v3
 from tests.api_full_response.test_full_response_base import TestFullResponseBase
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
@@ -48,7 +48,7 @@ class TesFullResponseSendDeploy(TestFullResponseBase):
                 "result": "0x4bf74e6aeeb43bde5dc8d5b62537a33ac8eb7605ebbdb51b015c1881b45b3aed"
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result_dict = self.icon_service.send_transaction(signed_transaction, full_response=True)
             actual_request = json.loads(m._adapter.last_request.text)
             result_content = result_dict['result']
@@ -80,7 +80,7 @@ class TesFullResponseSendDeploy(TestFullResponseBase):
                 }
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json, status_code=400)
+            m.post(self.matcher, json=response_json, status_code=400)
             result_dict = self.icon_service.send_transaction(signed_transaction, full_response=True)
             self.assertEqual(result_error_v3.keys(), result_dict.keys())
 

--- a/tests/api_full_response/test_send_deposit.py
+++ b/tests/api_full_response/test_send_deposit.py
@@ -13,17 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import requests_mock
 import json
-
 from unittest import main
 from unittest.mock import patch
+
+import requests_mock
+
 from iconsdk.builder.transaction_builder import DepositTransactionBuilder
 from iconsdk.signed_transaction import SignedTransaction
 from iconsdk.utils.validation import is_T_HASH
 from tests.api_full_response.example_response import result_success_v3
 from tests.api_full_response.test_full_response_base import TestFullResponseBase
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
@@ -71,7 +71,7 @@ class TesFullResponseSendDeposit(TestFullResponseBase):
                 "result": tx_hash,
                 "id": 1234
             }
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result_dict = self.icon_service.send_transaction(signed_transaction, full_response=True)
             actual_request = json.loads(m._adapter.last_request.text)
             result_content = result_dict['result']

--- a/tests/api_full_response/test_send_message.py
+++ b/tests/api_full_response/test_send_message.py
@@ -13,17 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import requests_mock
 import json
-
 from unittest import main
 from unittest.mock import patch
+
+import requests_mock
+
 from iconsdk.builder.transaction_builder import MessageTransactionBuilder
 from iconsdk.signed_transaction import SignedTransaction
 from iconsdk.utils.validation import is_message_transaction, is_T_HASH
 from tests.api_full_response.example_response import result_success_v3
 from tests.api_full_response.test_full_response_base import TestFullResponseBase
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
@@ -70,7 +70,7 @@ class TestFullResponseSendMessage(TestFullResponseBase):
                 'id': 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result_dict = self.icon_service.send_transaction(signed_transaction, full_response=True)
             actual_request = json.loads(m._adapter.last_request.text)
             result_content = result_dict['result']

--- a/tests/api_full_response/test_send_transfer.py
+++ b/tests/api_full_response/test_send_transfer.py
@@ -13,17 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import requests_mock
 import json
-
 from unittest import main
 from unittest.mock import patch
+
+import requests_mock
+
 from iconsdk.builder.transaction_builder import TransactionBuilder
 from iconsdk.signed_transaction import SignedTransaction
-from iconsdk.utils.validation import is_message_transaction, is_T_HASH
+from iconsdk.utils.validation import is_T_HASH
 from tests.api_full_response.example_response import result_success_v3
 from tests.api_full_response.test_full_response_base import TestFullResponseBase
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
@@ -50,7 +50,7 @@ class TestFullResponseSendTransfer(TestFullResponseBase):
                 "id": 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result_dict = self.icon_service.send_transaction(signed_transaction, full_response=True)
             actual_request = json.loads(m._adapter.last_request.text)
             result_content = result_dict['result']

--- a/tests/api_get/test_get_balance.py
+++ b/tests/api_get/test_get_balance.py
@@ -12,12 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import requests_mock
 import json
-
 from unittest import main
 from unittest.mock import patch
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
+
+import requests_mock
+
 from iconsdk.exception import AddressException
 from tests.api_send.test_send_super import TestSendSuper
 
@@ -42,7 +42,7 @@ class TestGetBalance(TestSendSuper):
                 "result": hex(0),
                 "id": 1234
             }
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result = self.icon_service.get_balance(self.setting["from"])
             actual_request = json.loads(m._adapter.last_request.text)
             self.assertEqual(expected_request, actual_request)

--- a/tests/api_get/test_get_block_by_hash.py
+++ b/tests/api_get/test_get_block_by_hash.py
@@ -12,15 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import requests_mock
 import json
-
 from unittest import main
 from unittest.mock import patch
-from tests.api_send.test_send_super import TestSendSuper
+
+import requests_mock
+
 from iconsdk.exception import DataTypeException, JSONRPCException
 from iconsdk.utils.hexadecimal import remove_0x_prefix
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
+from tests.api_send.test_send_super import TestSendSuper
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
@@ -67,7 +67,7 @@ class TestGetBlockByHash(TestSendSuper):
             }
 
             # case 0: when hash value of latest block is valid
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result = self.icon_service.get_block(block_hash)
             actual_request = json.loads(m._adapter.last_request.text)
             self.assertEqual(expected_request, actual_request)
@@ -97,7 +97,7 @@ class TestGetBlockByHash(TestSendSuper):
                      "message": "fail wrong block hash"
                  },
             }
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json, status_code=400)
+            m.post(self.matcher, json=response_json, status_code=400)
             self.assertRaises(JSONRPCException, self.icon_service.get_block, invalid_block_hash)
             actual_request = json.loads(m._adapter.last_request.text)
             self.assertEqual(expected_request, actual_request)

--- a/tests/api_get/test_get_block_by_height.py
+++ b/tests/api_get/test_get_block_by_height.py
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import requests_mock
 import json
-
 from unittest import main
 from unittest.mock import patch
-from tests.api_send.test_send_super import TestSendSuper
+
+import requests_mock
+
 from iconsdk.exception import DataTypeException, JSONRPCException
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
+from tests.api_send.test_send_super import TestSendSuper
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
@@ -66,7 +66,7 @@ class TestGetBlockByHeight(TestSendSuper):
                 "id": 1234
             }
             # case 0: when height is 0
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result = self.icon_service.get_block(height)
             actual_request = json.loads(m._adapter.last_request.text)
             self.assertEqual(expected_request, actual_request)
@@ -96,7 +96,7 @@ class TestGetBlockByHeight(TestSendSuper):
                 },
                 "id": 1234
             }
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json, status_code=400)
+            m.post(self.matcher, json=response_json, status_code=400)
             self.assertRaises(JSONRPCException, self.icon_service.get_block, wrong_height)
             actual_request = json.loads(m._adapter.last_request.text)
             self.assertEqual(expected_request, actual_request)

--- a/tests/api_get/test_get_last_block.py
+++ b/tests/api_get/test_get_last_block.py
@@ -12,14 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import requests_mock
 import json
-
 from unittest import main
 from unittest.mock import patch
-from tests.api_send.test_send_super import TestSendSuper
+
+import requests_mock
+
 from iconsdk.exception import DataTypeException
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
+from tests.api_send.test_send_super import TestSendSuper
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
@@ -60,7 +60,7 @@ class TestGetLastBlock(TestSendSuper):
                 "id": 1234
             }
             # case 0: when param is `latest`
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result = self.icon_service.get_block("latest")
             actual_request = json.loads(m._adapter.last_request.text)
             self.assertEqual(expected_request, actual_request)

--- a/tests/api_get/test_get_score_api.py
+++ b/tests/api_get/test_get_score_api.py
@@ -12,15 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import requests_mock
 import json
-
 from unittest import main
 from unittest.mock import patch
-from tests.api_send.test_send_super import TestSendSuper
+
+import requests_mock
+
 from iconsdk.exception import AddressException, JSONRPCException
 from iconsdk.utils.validation import is_score_apis
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
+from tests.api_send.test_send_super import TestSendSuper
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
@@ -38,7 +38,7 @@ class TestGetScoreApi(TestSendSuper):
                 }
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_governance_json)
+            m.post(self.matcher, json=response_governance_json)
             # case 0: when getting score apis successfully
             result = self.icon_service.get_score_api(governance_address)
             actual_request = json.loads(m._adapter.last_request.text)
@@ -74,7 +74,7 @@ class TestGetScoreApi(TestSendSuper):
                 },
                 "id": 1234
             }
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json, status_code=400)
+            m.post(self.matcher, json=response_json, status_code=400)
             # case 3: when the address is not score id
             self.assertRaises(JSONRPCException, self.icon_service.get_score_api, wrong_address)
             actual_request = json.loads(m._adapter.last_request.text)

--- a/tests/api_get/test_get_total_supply.py
+++ b/tests/api_get/test_get_total_supply.py
@@ -12,12 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import requests_mock
 import json
 from unittest import main
 from unittest.mock import patch
+
+import requests_mock
+
 from tests.api_send.test_send_super import TestSendSuper
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
@@ -37,7 +38,7 @@ class TestGetTotalSupply(TestSendSuper):
                 'result': hex(supply),
                 'id': 1234
             }
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             # case 0: when calling the method successfully
             result = self.icon_service.get_total_supply()
             actual_request = json.loads(m._adapter.last_request.text)

--- a/tests/api_get/test_get_transaction_by_hash.py
+++ b/tests/api_get/test_get_transaction_by_hash.py
@@ -12,16 +12,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import requests_mock
 import json
-
 from unittest import main
 from unittest.mock import patch
+
+import requests_mock
+
 from iconsdk.exception import JSONRPCException, DataTypeException
 from iconsdk.utils.hexadecimal import remove_0x_prefix, add_cx_prefix
 from iconsdk.utils.validation import is_transaction
 from tests.api_send.test_send_super import TestSendSuper
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
@@ -58,7 +58,7 @@ class TestGetTransactionByHash(TestSendSuper):
                 "id": 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             # case 0: when tx_hash is valid
             result = self.icon_service.get_transaction(tx_hash)
             actual_request = json.loads(m._adapter.last_request.text)
@@ -87,7 +87,7 @@ class TestGetTransactionByHash(TestSendSuper):
                 "id": 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json, status_code=400)
+            m.post(self.matcher, json=response_json, status_code=400)
             self.assertRaises(JSONRPCException, self.icon_service.get_transaction, wrong_tx_hash)
 
 

--- a/tests/api_get/test_get_transaction_result.py
+++ b/tests/api_get/test_get_transaction_result.py
@@ -13,17 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import requests_mock
 import json
-
 from unittest import main
 from unittest.mock import patch
+
+import requests_mock
 
 from iconsdk.exception import DataTypeException, JSONRPCException
 from iconsdk.utils.hexadecimal import remove_0x_prefix, add_cx_prefix
 from iconsdk.utils.validation import is_transaction_result
 from tests.api_send.test_send_super import TestSendSuper
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
@@ -66,7 +65,7 @@ class TestGetTransactionResult(TestSendSuper):
                 },
                 "id": 1234
             }
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result = self.icon_service.get_transaction_result(tx_hash)
             actual_request = json.loads(m._adapter.last_request.text)
             self.assertEqual(expected_request, actual_request)
@@ -91,7 +90,7 @@ class TestGetTransactionResult(TestSendSuper):
                 },
                 "id": 1234
             }
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", status_code=400, json=response_json)
+            m.post(self.matcher, json=response_json, status_code=400)
             # case 4: when tx_hash is invalid - not exist
             self.assertRaises(JSONRPCException, self.icon_service.get_transaction_result, wrong_tx_hash)
             actual_request = json.loads(m._adapter.last_request.text)

--- a/tests/api_send/test_send_deposit.py
+++ b/tests/api_send/test_send_deposit.py
@@ -1,12 +1,12 @@
-import requests_mock
 import json
-
 from unittest.mock import patch
+
+import requests_mock
+
 from iconsdk.builder.transaction_builder import DepositTransactionBuilder
 from iconsdk.signed_transaction import SignedTransaction
 from iconsdk.utils.validation import is_T_HASH
 from tests.api_send.test_send_super import TestSendSuper
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
@@ -55,7 +55,7 @@ class TestSendDeposit(TestSendSuper):
                 "result": tx_hash,
                 "id": 1234
             }
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result = self.icon_service.send_transaction(signed_transaction)
             actual_request = json.loads(m._adapter.last_request.text)
             self.assertEqual(expected_request, actual_request)
@@ -110,7 +110,7 @@ class TestSendDeposit(TestSendSuper):
                 "id": 1234
             }
             # Checks if sending transaction correctly
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result = self.icon_service.send_transaction(signed_transaction)
             self.assertTrue(is_T_HASH(result))
             actual_request = json.loads(m._adapter.last_request.text)

--- a/tests/api_send/test_send_message.py
+++ b/tests/api_send/test_send_message.py
@@ -12,11 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import requests_mock
 import json
-
 from unittest.mock import patch
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
+
+import requests_mock
+
 from iconsdk.builder.transaction_builder import MessageTransactionBuilder
 from iconsdk.exception import JSONRPCException, DataTypeException
 from iconsdk.signed_transaction import SignedTransaction
@@ -68,7 +68,7 @@ class TestSendMessage(TestSendSuper):
                 'id': 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result = self.icon_service.send_transaction(signed_transaction)
             self.assertTrue(is_T_HASH(result))
             actual_request = json.loads(m._adapter.last_request.text)
@@ -104,7 +104,7 @@ class TestSendMessage(TestSendSuper):
                 "id": 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result = self.icon_service.get_transaction_result(tx_hash)
             self.assertTrue(is_transaction_result(result))
 
@@ -163,7 +163,7 @@ class TestSendMessage(TestSendSuper):
                 "id": 1234
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result = self.icon_service.get_block(int('0x13f', 16))
             self.assertTrue(is_block(result))
             self.assertEqual(result["confirmed_transaction_list"][1]["data"], self.setting["data"])
@@ -190,7 +190,7 @@ class TestSendMessage(TestSendSuper):
                 },
                 "id": 1234
             }
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json, status_code=400)
+            m.post(self.matcher, json=response_json, status_code=400)
             # When address is wrong
             message_transaction = MessageTransactionBuilder().from_(self.setting["from"]).to(self.setting["to"][2:]) \
                 .step_limit(self.setting["step_limit"]).nid(self.setting["nid"]).data(self.setting["data"]).build()

--- a/tests/api_send/test_send_super.py
+++ b/tests/api_send/test_send_super.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import re
 from unittest import TestCase, main
 
 from iconsdk.icon_service import IconService
@@ -27,6 +28,7 @@ class TestSendSuper(TestCase):
     A super class of other send test class, it is for unit tests of sending transaction.
     All of sup classes for testing sending transaction extends this super class.
     """
+    matcher = re.compile(re.escape(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/") + "?")
 
     @classmethod
     def setUpClass(cls):

--- a/tests/api_send/test_send_transfer.py
+++ b/tests/api_send/test_send_transfer.py
@@ -13,15 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+from unittest.mock import patch
+
 import requests_mock
 
-from unittest.mock import patch
 from iconsdk.builder.transaction_builder import TransactionBuilder
 from iconsdk.exception import JSONRPCException, DataTypeException
 from iconsdk.signed_transaction import SignedTransaction
 from iconsdk.utils.validation import is_icx_transaction, is_T_HASH
 from tests.api_send.test_send_super import TestSendSuper
-from tests.example_config import BASE_DOMAIN_URL_V3_FOR_TEST
 
 
 @patch('iconsdk.providers.http_provider.HTTPProvider._make_id', return_value=1234)
@@ -66,7 +66,7 @@ class TestSendTransfer(TestSendSuper):
                 "result": tx_hash,
                 "id": 1234
             }
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             result = self.icon_service.send_transaction(signed_transaction)
             self.assertTrue(is_T_HASH(result))
             actual_request = json.loads(m._adapter.last_request.text)
@@ -122,7 +122,7 @@ class TestSendTransfer(TestSendSuper):
                 "id": 5
             }
 
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", status_code=500, json=response_json)
+            m.post(self.matcher, json=response_json, status_code=500)
             self.assertRaises(JSONRPCException, self.icon_service.send_transaction, signed_transaction)
             actual_request = json.loads(m._adapter.last_request.text)
             self.assertEqual(expected_request, actual_request)

--- a/tests/wallet/test_wallet_load_from_keystore_file.py
+++ b/tests/wallet/test_wallet_load_from_keystore_file.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import re
 
 import requests_mock
 from unittest.mock import patch
@@ -31,6 +32,7 @@ class TestWalletLoadFromKeystoreFile(TestCase):
     TEST_KEYSTORE_FILE_PATH = path.abspath(path.join(TEST_CUR_DIR, '../keystore_file/test_keystore.txt'))
 
     TEST_KEYSTORE_FILE_PASSWORD = "Adas21312**"
+    matcher = re.compile(re.escape(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/") + "?")
 
     def test_wallet_load_from_keystore_file(self):
         """A wallet loads from a keystore file correctly."""
@@ -68,7 +70,7 @@ class TestWalletLoadFromKeystoreFile(TestCase):
                 "result": hex(0),
                 "id": 1234
             }
-            m.post(f"{BASE_DOMAIN_URL_V3_FOR_TEST}/api/v3/", json=response_json)
+            m.post(self.matcher, json=response_json)
             balance = icon_service.get_balance(wallet.get_address())
             self.assertEqual(balance, 0)
 


### PR DESCRIPTION
If channel is empty string, url end with '/'. This regard as empty
string of channel path. Mainnet `iconrpcserver` using default channel if
channel path is None.
Empty string of channel path raise exception.

related : https://github.com/icon-project/icon-rpc-server/commit/5e95a91fb14829f6309d663c5004ee56759d35f8
