### PR TITLE
Apply to accept PathLike by wallet

### DIFF
--- a/iconsdk/providers/http_provider.py
+++ b/iconsdk/providers/http_provider.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018 ICON Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +20,7 @@ from typing import Union
 from urllib.parse import urlparse
 
 import requests
-from multipledispatch import dispatch
+from multimethod import multimethod
 
 from iconsdk.exception import JSONRPCException, URLException
 from iconsdk.providers.provider import Provider
@@ -34,7 +33,7 @@ class HTTPProvider(Provider):
     For local development this would be something like 'http://localhost:9000'.
     """
 
-    @dispatch(str, int, dict=None)
+    @multimethod
     def __init__(self, base_domain_url: str, version: int, request_kwargs: dict = None):
         """
         The initializer to be set with base domain URL and version.
@@ -52,7 +51,7 @@ class HTTPProvider(Provider):
         self._request_kwargs = request_kwargs or {}
         self._generate_url_map()
 
-    @dispatch(str, dict=None)
+    @multimethod
     def __init__(self, full_path_url: str, request_kwargs: dict = None):
         """
         The initializer to be set with full path url as like <scheme>://<host>:<port>/api/v3.

--- a/iconsdk/utils/__init__.py
+++ b/iconsdk/utils/__init__.py
@@ -13,21 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from functools import wraps
-from logging import StreamHandler, Formatter
-from os import path
+from logging import Formatter, StreamHandler
 from time import time
+from typing import Union
 
 from iconsdk import logger
 
+# https://docs.python.org/3/glossary.html#term-path-like-object
+PathLikeObject = Union[str, bytes, os.PathLike]
 
-def store_keystore_file_on_the_path(file_path, json_string):
+
+def store_keystore_file_on_the_path(file_path: PathLikeObject, json_string: str):
     """Stores a created keystore string data which is JSON format on the file path.
 
     :param file_path: The path where the file will be saved. type(str)
     :param json_string: Contents of the keystore.
     """
-    if path.isfile(file_path):
+    if os.path.isfile(file_path):
         raise FileExistsError
 
     with open(file_path, 'wt') as f:

--- a/iconsdk/utils/typing/conversion.py
+++ b/iconsdk/utils/typing/conversion.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Any
+from __future__ import annotations
+
+from typing import Any
 
 from ...wallet.wallet import Wallet
 
@@ -57,7 +59,7 @@ def base_object_to_str(value: Any) -> str:
     raise TypeError(f"Unsupported type: {type(value)}")
 
 
-def object_to_str(value: Any) -> Union[Any]:
+def object_to_str(value: Any) -> Any | None:
     if is_base_type(type(value)):
         return base_object_to_str(value)
 

--- a/iconsdk/wallet/wallet.py
+++ b/iconsdk/wallet/wallet.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018 ICON Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
 import warnings
 from abc import ABCMeta, abstractmethod
@@ -20,12 +21,12 @@ from hashlib import sha3_256
 
 from coincurve import PrivateKey
 from eth_keyfile import create_keyfile_json, extract_key_from_keyfile
-from multipledispatch import dispatch
+from multimethod import multimethod
 
 from iconsdk import logger
-from iconsdk.exception import KeyStoreException, DataTypeException
+from iconsdk.exception import DataTypeException, KeyStoreException
 from iconsdk.libs.signer import sign
-from iconsdk.utils import store_keystore_file_on_the_path
+from iconsdk.utils import PathLikeObject, store_keystore_file_on_the_path
 from iconsdk.utils.validation import is_keystore_file
 
 
@@ -68,9 +69,8 @@ class KeyWallet(Wallet):
         logger.info(f"Created Wallet. Address: {wallet.get_address()}")
         return wallet
 
-    @staticmethod
-    @dispatch(bytes)
-    def load(private_key: bytes) -> 'KeyWallet':
+    @multimethod
+    def load(private_key: bytes) -> KeyWallet:
         """Loads a wallet from a private key and generates an instance of Wallet.
 
         :param private_key: private key in bytes
@@ -85,11 +85,11 @@ class KeyWallet(Wallet):
             raise DataTypeException("Private key is invalid.")
 
     @staticmethod
-    @dispatch(str, str)
-    def load(file_path: str, password: str) -> 'KeyWallet':
+    @multimethod
+    def load(file_path: PathLikeObject, password: str) -> KeyWallet:
         """Loads a wallet from a keystore file with your password and generates an instance of Wallet.
 
-        :param file_path: File path of the keystore file. type(str)
+        :param file_path: File path of the keystore file. type(str | bytes | PathLike)
         :param password:
             Password for the keystore file.
             It must include alphabet character, number, and special character.
@@ -110,10 +110,10 @@ class KeyWallet(Wallet):
         except Exception as e:
             raise KeyStoreException(f'Keystore error: {e}')
 
-    def store(self, file_path: str, password: str):
+    def store(self, file_path: PathLikeObject, password: str):
         """Stores data of an instance of a derived wallet class on the file path with your password.
 
-        :param file_path: File path of the keystore file. type(str)
+        :param file_path: File path of the keystore file. type(str | bytes | PathLike)
         :param password:
             Password for the keystore file. Password must include alphabet character, number, and special character.
             type(str)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 eth-keyfile~=0.5.1
 coincurve~=13.0.0
-multipledispatch~=0.6.0
+multimethod~=1.9.1
 requests>=2.20.0
 requests-mock~=1.8.0

--- a/tests/wallet/test_wallet_load_from_keystore_file.py
+++ b/tests/wallet/test_wallet_load_from_keystore_file.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pathlib
 import re
 
 import requests_mock
@@ -39,6 +40,13 @@ class TestWalletLoadFromKeystoreFile(TestCase):
 
         # Loads a wallet.
         wallet = KeyWallet.load(self.TEST_KEYSTORE_FILE_PATH, self.TEST_KEYSTORE_FILE_PASSWORD)
+
+        # Checks a wallet's address is correct.
+        self.assertEqual(wallet.get_address(), "hxfd7e4560ba363f5aabd32caac7317feeee70ea57")
+
+        # Loads a wallet using path-like object.
+        keystore_path = pathlib.Path(self.TEST_KEYSTORE_FILE_PATH)
+        wallet = KeyWallet.load(keystore_path, self.TEST_KEYSTORE_FILE_PASSWORD)
 
         # Checks a wallet's address is correct.
         self.assertEqual(wallet.get_address(), "hxfd7e4560ba363f5aabd32caac7317feeee70ea57")


### PR DESCRIPTION
`wallet` support [path-like object](https://docs.python.org/3/glossary.html#term-path-like-object) as filepath when `load` and `store`.

```python
file_path = pathlib.Path("keystore.json")
wallet.load(file_path, "keystore_password")
```